### PR TITLE
forcing installation of plex-archive-keyring package prior to installing plexmediaserver

### DIFF
--- a/recipes/server_ubuntu.rb
+++ b/recipes/server_ubuntu.rb
@@ -28,7 +28,7 @@ end
 package "plex-archive-keyring" do
   options "--force-yes"
   action :install
-  notifies :run, resources('execute[apt-get update]'), :immediately
+  notifies :run, "execute[apt-get update]", :immediately
 end
 
 package "plexmediaserver"


### PR DESCRIPTION
This cookbook didn't work for me out of the box; apt was unhappy about the packages being unsigned. 

Since it seems the repo maintainers haven't published their key on the default servers, I've modified the server_ubuntu recipe to force install the needed key from another package in the repo, then run apt-get update before installing plexmediaserver.
